### PR TITLE
Display the number of tracks with a duration of up to 100 minutes (incl.), using the aggregate() method

### DIFF
--- a/VovkozubovViacheslav/audiohosting.js
+++ b/VovkozubovViacheslav/audiohosting.js
@@ -1,0 +1,6 @@
+// Вывести ко-во треков с продолжительностью до 100 мин (вкл.), используя метод aggregate()
+
+db.tracks.aggregate([
+    { $match: { duration_secs: { $lte: 100 * 60 } } },
+    { $count: 'total' }
+])


### PR DESCRIPTION
 Вывести ко-во треков с продолжительностью до 100 мин (вкл.), используя метод aggregate()